### PR TITLE
Removed DNS_REQUEST

### DIFF
--- a/draft-ietf-masque-connect-ip-dns.md
+++ b/draft-ietf-masque-connect-ip-dns.md
@@ -368,8 +368,8 @@ This document, if approved, will request IANA add the following value to the
 
 Value:
 
-: 0x1ACE79EC (if this document is approved, the values defined above will be
-replaced by smaller ones before publication)
+: 0x1ACE79EC (if this document is approved, this value will be
+replaced by a smaller one before publication)
 
 Capsule Type:
 

--- a/draft-ietf-masque-connect-ip-dns.md
+++ b/draft-ietf-masque-connect-ip-dns.md
@@ -267,7 +267,6 @@ an endpoint to send DNS configuration to its peer.
 DNS_ASSIGN Capsule {
   Type (i) = DNS_ASSIGN,
   Length (i),
-  DNS Configuration Count (i),
   DNS Configuration (..) ...,
 }
 ~~~
@@ -367,15 +366,14 @@ This document, if approved, will request IANA add the following value to the
 "HTTP Capsule Types" registry maintained at
 <[](https://www.iana.org/assignments/masque)>.
 
-|   Value   | Capsule Type |
-|:----------|:-------------|
-| 0x818F79E |  DNS_ASSIGN  |
-{: #iana-capsules-table title="New Capsule"}
+Value:
 
-Note that, if this document is approved, the values defined above will be
-replaced by smaller ones before publication.
+: 0x1ACE79EC (if this document is approved, the values defined above will be
+replaced by smaller ones before publication)
 
-All of these new entries use the following values for these fields:
+Capsule Type:
+
+: DNS_ASSIGN
 
 Status:
 


### PR DESCRIPTION
As discussed at last WG meeting I removed DNS_REQUEST.

Few other relevant changes:
- DNS_ASSIGN no longer have Request ID
- DNS_ASSIGN contains a list of DNS Configurations. This may be useful for split-DNS setups where separate DNS Servers provide services for various internal domains
- Clarified that DNS_ASSIGN supersedes previous DNS_ASSIGNs sent in the same direction